### PR TITLE
Opentelemetry + validators + performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,7 @@
   :plugins [[test2junit "1.2.2"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [medley "1.3.0"]
+                 [org.cyverse/otel "0.2.0-SNAPSHOT"]
                  [org.cyverse/clojure-commons "2.8.3"]
                  [org.cyverse/clj-icat-direct "2.8.8"
                    :exclusions [[org.slf4j/slf4j-log4j12]

--- a/project.clj
+++ b/project.clj
@@ -10,10 +10,10 @@
                  [medley "1.3.0"]
                  [org.cyverse/otel "0.2.0-SNAPSHOT"]
                  [org.cyverse/clojure-commons "2.8.3"]
-                 [org.cyverse/clj-icat-direct "2.8.8"
+                 [org.cyverse/clj-icat-direct "2.8.9-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
-                 [org.cyverse/clj-jargon "2.8.11"
+                 [org.cyverse/clj-jargon "2.8.12-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [slingshot "0.12.2"]])

--- a/src/clj_irods/core.clj
+++ b/src/clj_irods/core.clj
@@ -105,9 +105,8 @@
 
 (defmacro instrumented-delay
   [& body]
-  `(otel/with-span [s# ["delay context" {:kind :internal}]]
-     (delay (with-open [_# (otel/span-scope s#)]
-              (otel/with-span [s2# ["delay body" {:kind :internal}]] ~@body)))))
+  `(delay (with-open [_# (otel/span-scope (otel/current-span))]
+              (otel/with-span [s2# ["delay body" {:kind :internal}]] ~@body))))
 
 (defn- from-listing
   [cache? irods extract-fn user zone path]

--- a/src/clj_irods/core.clj
+++ b/src/clj_irods/core.clj
@@ -56,8 +56,8 @@
       (do ~@body))))
 
 (defmacro maybe-icat-transaction
-  [use-icat & body]
-  `(if ~use-icat
+  [use-icat-transaction & body]
+  `(if ~use-icat-transaction
      (icat-direct/with-icat-transaction
        (do ~@body))
      (do ~@body)))
@@ -84,10 +84,11 @@
            jargon-opts# (or (:jargon-opts ~cfg) {})
            use-jargon# (boolean jargon-cfg#)
            use-icat# (have-icat)
+           use-icat-transaction# (and use-icat# (get ~cfg :use-icat-transaction true))
            jargon-pool# (or (:combined-pool ~cfg) (:jargon-pool ~cfg) (make-threadpool (str id# "-jargon") (or (:jargon-pool-size ~cfg) 1)))
            icat-pool#   (or (:combined-pool ~cfg) (:icat-pool ~cfg) (make-threadpool (str id# "-icat") (or (:icat-pool-size ~cfg) 5)))]
        (try+
-         (maybe-icat-transaction use-icat#
+         (maybe-icat-transaction use-icat-transaction#
            (maybe-jargon use-jargon# jargon-cfg# jargon-opts# jargon#
              (let [~sym {:jargon      jargon#
                          :jargon-pool jargon-pool#

--- a/src/clj_irods/icat.clj
+++ b/src/clj_irods/icat.clj
@@ -8,6 +8,26 @@
             [clojure.tools.logging :as log]
             [clj-icat-direct.icat :as icat]))
 
+;; user
+(defn- user*
+  [irods username zone]
+  (->> [username zone ::user]
+       (cache/cached-or-do (:cache irods) #(icat/user username zone))))
+
+(defn user
+  [irods username zone]
+  (->> [username zone ::user]
+       (cache/cached-or-agent (:cache irods) #(user* irods username zone) (:icat-pool irods))))
+
+(defn cached-user
+  [irods username zone]
+  (->> [username zone ::user]
+       (cache/cached-or-nil (:cache irods))))
+
+(defn maybe-user
+  [irods username zone]
+  (delay (deref (user irods username zone))))
+
 ;; user-group-ids
 (defn- user-group-ids*
   [irods user zone]

--- a/src/clj_irods/validate.clj
+++ b/src/clj_irods/validate.clj
@@ -1,0 +1,67 @@
+(ns clj-irods.validate
+  (:require [clojure-commons.error-codes :as error]
+            [clojure.tools.logging :as log]
+            [slingshot.slingshot :refer [throw+]]
+            [clj-jargon.permissions :as jargon-perms]
+            [clj-irods.core :as rods]))
+
+(defn validate
+  "Validate a set of things in iRODS.
+
+  Each validation is a vector of a keyword (identifying the kind of validation)
+  and any relevant arguments. The validations will be run in the provided order.
+
+  Available validations and their arguments:
+
+  :user-exists (string or vector, users to check), (string zone)
+  :path-exists (string or vector, path or paths to check), (string user), (string zone)
+  :path-is-file (string or vector, path or paths to check), (string user), (string zone)
+  :path-is-dir (string or vector, path or paths to check), (string user), (string zone)
+  :path-readable (string or vector, path or paths to check), (string user), (string zone)
+  :path-writeable (string or vector, path or paths to check), (string user), (string zone)
+  :path-owned (string or vector, path or paths to check), (string user), (string zone)
+  "
+  [irods & validations]
+
+  (doseq [v validations]
+    (condp = (first v)
+      :user-exists (let [[users zone] (rest v)]
+                     (doseq [u (if (vector? users) users [users])]
+                       (when (= @(rods/user-type irods u zone) :none)
+                         (log/info (:cache irods))
+                         (throw+ {:error_code error/ERR_NOT_A_USER
+                                  :user u}))))
+      :path-exists (let [[paths user zone] (rest v)]
+                     (doseq [p (if (vector? paths) paths [paths])]
+                       (when (= @(rods/object-type irods user zone p) :none)
+                         (throw+ {:error_code error/ERR_DOES_NOT_EXIST
+                                  :path p}))))
+      :path-is-file (let [[paths user zone] (rest v)]
+                      (doseq [p (if (vector? paths) paths [paths])]
+                        (when-not (= @(rods/object-type irods user zone p) :file)
+                          (throw+ {:error_code error/ERR_NOT_A_FILE
+                                   :path p}))))
+      :path-is-dir (let [[paths user zone] (rest v)]
+                     (doseq [p (if (vector? paths) paths [paths])]
+                       (when-not (= @(rods/object-type irods user zone p) :dir)
+                         (throw+ {:error_code error/ERR_NOT_A_FOLDER
+                                  :path p}))))
+      :path-readable (let [[paths user zone] (rest v)]
+                       (doseq [p (if (vector? paths) paths [paths])]
+                         (when-not (contains? #{:read :write :own} @(rods/permission irods user zone p))
+                           (throw+ {:error_code error/ERR_NOT_READABLE
+                                    :path p
+                                    :user user}))))
+      :path-writeable (let [[paths user zone] (rest v)]
+                       (doseq [p (if (vector? paths) paths [paths])]
+                         (when-not (contains? #{:write :own} @(rods/permission irods user zone p))
+                           (throw+ {:error_code error/ERR_NOT_READABLE
+                                    :path p
+                                    :user user}))))
+      :path-owned (let [[paths user zone] (rest v)]
+                       (doseq [p (if (vector? paths) paths [paths])]
+                         (when-not (= :own @(rods/permission irods user zone p))
+                           (throw+ {:error_code error/ERR_NOT_READABLE
+                                    :path p
+                                    :user user}))))
+      (log/warn "Unrecognized validation type:" (first v)))))

--- a/src/clj_irods/validate.clj
+++ b/src/clj_irods/validate.clj
@@ -28,7 +28,6 @@
       :user-exists (let [[users zone] (rest v)]
                      (doseq [u (if (vector? users) users [users])]
                        (when (= @(rods/user-type irods u zone) :none)
-                         (log/info (:cache irods))
                          (throw+ {:error_code error/ERR_NOT_A_USER
                                   :user u}))))
       :path-exists (let [[paths user zone] (rest v)]


### PR DESCRIPTION
Adds opentelemetry instrumentation a bunch of places, first of all.

Fixes a few errors and misoptimized bits here and there.

Adds functions for getting users (using the clj-jargon/clj-icat-direct changes).

Adds a big validate function that can do a variety of validations and uses this library, so it benefits from (and helps fill) the cache.