### PR TITLE
Use new path-for-uuid function from clj-icat-direct for uuid->path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [medley "1.3.0"]
                  [org.cyverse/otel "0.2.0"]
                  [org.cyverse/clojure-commons "2.8.3"]
-                 [org.cyverse/clj-icat-direct "2.8.9"
+                 [org.cyverse/clj-icat-direct "2.8.10-SNAPSHOT"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clj-jargon "2.8.12"

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [medley "1.3.0"]
                  [org.cyverse/otel "0.2.0"]
                  [org.cyverse/clojure-commons "2.8.3"]
-                 [org.cyverse/clj-icat-direct "2.8.10-SNAPSHOT"
+                 [org.cyverse/clj-icat-direct "2.8.10"
                    :exclusions [[org.slf4j/slf4j-log4j12]
                                 [log4j]]]
                  [org.cyverse/clj-jargon "2.8.12"

--- a/src/clj_irods/core.clj
+++ b/src/clj_irods/core.clj
@@ -144,7 +144,8 @@
                               (instrumented-delay (post-fn extracted))))]
     (when-let [metadata (if cache?
                           (jargon/cached-get-metadata irods path)
-                          (jargon/get-metadata irods path :known-type @(object-type irods user zone path)))]
+                          (when (:has-jargon irods)
+                            (jargon/get-metadata irods path :known-type @(object-type irods user zone path))))]
       (or (get-from-metadata metadata) nil))))
 
 (defn- cached-or-get
@@ -217,7 +218,8 @@
                                           (instrumented-delay found))))]
              (when-let [metadata (if cache?
                                    (jargon/cached-get-metadata irods path)
-                                   (jargon/get-metadata irods path :known-type @(object-type irods user zone path)))]
+                                   (when (:has-jargon irods)
+                                     (jargon/get-metadata irods path :known-type @(object-type irods user zone path))))]
                (get-avu metadata)))) path user zone avu])))
 
 (def uuid-attr "ipc_UUID")
@@ -249,8 +251,8 @@
       [(fn [cache? irods user path]
          (if cache?
            (jargon/cached-permission-for irods user path)
-           (instrumented-delay
-             @(jargon/permission-for irods user path :known-type @(object-type irods user zone path)))))
+           (when (:has-jargon irods) (instrumented-delay
+             @(jargon/permission-for irods user path :known-type @(object-type irods user zone path))))))
        user path])))
 
 (defn folder-listing
@@ -274,16 +276,16 @@
           cached-range (and cached (icat/get-range cached limit offset))]
       (if cached-range
         cached-range
-        (let [userids (icat/user-group-ids irods user zone)]
-        (instrumented-delay
-          (force userids)
-          @(icat/paged-folder-listing irods user zone path
-                                      :entity-type entity-type
-                                      :sort-column sort-column
-                                      :sort-direction sort-direction
-                                      :limit limit
-                                      :offset offset
-                                      :info-types info-types)))))))
+        (when (:has-icat irods) (let [userids (icat/user-group-ids irods user zone)]
+          (instrumented-delay
+            (force userids)
+            @(icat/paged-folder-listing irods user zone path
+                                        :entity-type entity-type
+                                        :sort-column sort-column
+                                        :sort-direction sort-direction
+                                        :limit limit
+                                        :offset offset
+                                        :info-types info-types))))))))
 
 (defn items-in-folder
   "Count of items in folder. This uses a listing under the hood, and considers
@@ -297,7 +299,7 @@
       (instrumented-delay (get-in (first
                        (if cached
                          (first (icat/flatten-cached-listings @cached))
-                         (deref (icat/paged-folder-listing irods user zone path :entity-type entity-type :info-types info-types))))
+                         (when (:has-icat irods) (deref (icat/paged-folder-listing irods user zone path :entity-type entity-type :info-types info-types)))))
                      [:total_count])))))
 
 (defn user-type

--- a/src/clj_irods/core.clj
+++ b/src/clj_irods/core.clj
@@ -308,12 +308,14 @@
       [(fn [cache? irods username zone]
          (when-let [user (if cache?
                            (icat/cached-user irods username zone)
-                           (icat/user irods username zone))]
+                           (when (:has-icat irods)
+                             (icat/user irods username zone)))]
            (delay (if (:user_type_name @user) :user :none)))) username zone] ; for now mimicking jargon version that doesn't distingush
       [(fn [cache? irods username zone]
          (when-let [user (if cache?
                            (jargon/cached-get-user irods username zone)
-                           (jargon/get-user irods username zone))]
+                           (when (:has-jargon irods)
+                             (jargon/get-user irods username zone)))]
            (delay (:type @user)))) username zone])))
 
 (defn uuid->path
@@ -323,5 +325,11 @@
     (cached-or-get irods
       [(fn [cache? irods uuid]
          (if cache?
+           (icat/cached-path-for-uuid irods uuid)
+           (when (:has-icat irods)
+             (icat/path-for-uuid irods uuid)))) uuid]
+      [(fn [cache? irods uuid]
+         (if cache?
            (jargon/cached-get-path irods uuid)
-           (jargon/get-path irods uuid))) uuid])))
+           (when (:has-jargon irods)
+             (jargon/get-path irods uuid)))) uuid])))

--- a/src/clj_irods/icat.clj
+++ b/src/clj_irods/icat.clj
@@ -254,3 +254,23 @@
 (defn maybe-get-item
   [irods user zone path & {:keys [user-group-ids]}]
   (delay (deref (get-item irods user zone path :user-group-ids user-group-ids))))
+
+;; path-for-uuid
+(defn- path-for-uuid*
+  [irods uuid]
+    (->> [uuid ::path-for-uuid]
+         (cache/cached-or-do (:cache irods) #(icat/path-for-uuid uuid))))
+
+(defn path-for-uuid
+  [irods uuid]
+  (->> [uuid ::path-for-uuid]
+       (cache/cached-or-agent (:cache irods) #(path-for-uuid* irods uuid) (:icat-pool irods))))
+
+(defn cached-path-for-uuid
+  [irods uuid]
+  (->> [uuid ::path-for-uuid]
+       (cache/cached-or-nil (:cache irods))))
+
+(defn maybe-path-for-uuid
+  [irods uuid]
+  (delay (deref (path-for-uuid uuid))))

--- a/src/clj_irods/validate.clj
+++ b/src/clj_irods/validate.clj
@@ -28,12 +28,12 @@
       (condp = (first v)
         :user-exists (let [[users zone] (rest v)]
                        (doseq [u (if (vector? users) users [users])]
-                         (when (= @(rods/user-type irods u zone) :none)
+                         (when (or (nil? u) (= @(rods/user-type irods u zone) :none))
                            (throw+ {:error_code error/ERR_NOT_A_USER
                                     :user u}))))
         :path-exists (let [[paths user zone] (rest v)]
                        (doseq [p (if (vector? paths) paths [paths])]
-                         (when (= @(rods/object-type irods user zone p) :none)
+                         (when (or (nil? p) (= @(rods/object-type irods user zone p) :none))
                            (throw+ {:error_code error/ERR_DOES_NOT_EXIST
                                     :path p}))))
         :path-is-file (let [[paths user zone] (rest v)]

--- a/src/clj_irods/validate.clj
+++ b/src/clj_irods/validate.clj
@@ -36,6 +36,11 @@
                          (when (or (nil? p) (= @(rods/object-type irods user zone p) :none))
                            (throw+ {:error_code error/ERR_DOES_NOT_EXIST
                                     :path p}))))
+        :path-not-exists (let [[paths user zone] (rest v)]
+                           (doseq [p (if (vector? paths) paths [paths])]
+                             (when-not (= @(rods/object-type irods user zone p) :none)
+                               (throw+ {:error_code error/ERR_EXISTS
+                                        :path p}))))
         :path-is-file (let [[paths user zone] (rest v)]
                         (doseq [p (if (vector? paths) paths [paths])]
                           (when-not (= @(rods/object-type irods user zone p) :file)


### PR DESCRIPTION
Use https://github.com/cyverse-de/clj-icat-direct/pull/9

also, fix a thing where we weren't properly guarding against the lack of icat/jargon support in a given with-irods block