### PR TITLE
CORE-2160: dependency updates

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,15 +8,16 @@
   :plugins [[jonase/eastwood "1.4.3"]
             [lein-ancient "0.7.0"]
             [test2junit "1.4.4"]]
-  :profiles {:repl {:dependencies [[cheshire "6.0.0"]]
+  :profiles {:repl {:dependencies [[cheshire "5.13.0"]]
                     :source-paths ["repl"]}}
-  :dependencies [[org.clojure/clojure "1.12.1"]
-                 [medley "1.4.0"]
-                 [org.cyverse/clojure-commons "3.0.11"]
+  :dependencies [[org.clojure/clojure "1.12.5"]
+                 [dev.weavejester/medley "1.10.0"]
+                 [org.cyverse/clojure-commons "3.0.12"
+                  :exclusions [[medley]]]
                  [org.cyverse/clj-icat-direct "2.9.7"
-                   :exclusions [[org.slf4j/slf4j-log4j12]
-                                [log4j]]]
-                 [org.cyverse/clj-jargon "3.1.4"
-                   :exclusions [[org.slf4j/slf4j-log4j12]
-                                [log4j]]]
+                  :exclusions [[org.slf4j/slf4j-log4j12]
+                               [log4j]]]
+                 [org.cyverse/clj-jargon "3.1.5"
+                  :exclusions [[org.slf4j/slf4j-log4j12]
+                               [log4j]]]
                  [slingshot "0.12.2"]])


### PR DESCRIPTION
These changes are fairly straightforward, but there are a couple of confusing changes:

- I downgraded `cheshire` because of a potential dependency conflict between it and Jargon. Newer versions of `cheshire` use newer versions of Jackson than Jargon does, so I don't want to risk encountering dependency issues with a small change like this one.
- I added `medley` as an exclusion for `clojure-commons` because with the switch to `dev.weavejester/medley` an older version of `medley` was being loaded and breaking things.

Everything else was routine.